### PR TITLE
More token url flexibility

### DIFF
--- a/tests/EmailTokenTest.php
+++ b/tests/EmailTokenTest.php
@@ -99,9 +99,9 @@ class EmailTokenTest extends TestCase
         $result = (new EmailToken)->sendEmail(
             $this->mockPHPMailer(),
             'to@example.com',
-            'dev.example.com',
             'Password reset',
-            "Set a new password @ https://{{ host }}/verify/{{ token }}\n\nLink expires in {{ expiry }} mins!"
+            'https://dev.example.com/verify/{{ token }}',
+            "Set a new password @ {{ url }}\n\nLink expires in {{ expiry }} mins!"
         );
 
         $this->assertCount(1, $result['to']);


### PR DESCRIPTION
I have a case where i want to use the same template with different URL's. You can already switch out the host so it would be nice to switch out the entire URL in the same way.

I did look at making this change backwards compatible but it seemed messy and a breaking change on a new major version may be best. 