### PR TITLE
Remove APP_ENV from CI builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,9 +9,6 @@ on:
     branches:
       - master
 
-env:
-  APP_ENV: test
-
 jobs:
   build:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
This is unused afaik.